### PR TITLE
Update Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,22 @@
-FROM deanturpin/dev
+# Build with: docker build --platfrom linux/amd64 -t shh .
+# This is necessary because the build container (deanturpin/dev) is linux/amd64 and the runtime container is multi-platform.
+FROM deanturpin/dev as build
 
 WORKDIR /root/shh
 COPY . .
 
 RUN make
+
+FROM ubuntu:latest
+
+RUN apt-get update && \
+    apt-get install -y figlet iproute2 libpcap0.8t64 && \
+    apt-get clean
+
+COPY --from=build /root/shh/build/shh /root/shh/build/shh
+
+WORKDIR /root/shh
+
 CMD figlet deanturpin/shh && \
     ip -brief addr && \
     stdbuf -o0 -e0 build/shh


### PR DESCRIPTION
Fixes #10 

Use a multistage build, copying the output of the application build process and only installing the necessary packages in the runtime stage

Building the image with `docker build --platfrom linux/amd64 -t shh .` fixes #10 